### PR TITLE
fix: Remove deprecated call to async_forward_entry_setup

### DIFF
--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -21,7 +21,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.data.setdefault(DOMAIN, {})
 
     # Forward the setup to the sensor platform (sensor.py)
-    return await hass.config_entries.async_forward_entry_setup(entry, Platform.SENSOR)
+    await hass.config_entries.async_forward_entry_setups(entry, [Platform.SENSOR])
+
+    return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:


### PR DESCRIPTION
* this is needed to upgrade to HA Core 2025.6 and later
* fixes #9 